### PR TITLE
fix: Add support for new Millennium config

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -1,4 +1,22 @@
 {
+    "Conditions": {
+        "2015 Theme": {
+            "default": "no",
+            "description": "Bluer but still old",
+            "values": {
+                "no": {
+                    "TargetCss": {
+                        "affects": [".*"],  "src": "2013steam/vars2013.css"
+                    }
+                },
+                "yes": {
+                    "TargetCss": {
+                        "affects": [".*"], "src": "2015steam/vars2015.css"
+                    }
+                }
+            }
+        }
+    },
     "Configuration": [
         {
             "Name": "2015 Theme",


### PR DESCRIPTION
Yes, I meant to leave the old on there. It will be there until all users are on the new version of Millennium.

I'll PR remove it when its good to be removed.