### PR TITLE
Chat window fixes

### DIFF
--- a/friends.custom.css
+++ b/friends.custom.css
@@ -851,6 +851,27 @@ form._3Ule3rolhZJiBN4yNNtk1s, ._2WfNoLBdfKwyutA6ho4aSH .RVIs84dAE6wHcjH9tkinc, .
     max-height: 100%;
 }
 
+.chatHistory {
+    padding-bottom: 24px !important;
+}
+
+.chatEntry form textarea:hover {
+    cursor: text !important;
+}
+
+.chatEntry form textarea {
+    scrollbar-width: none;
+}
+
+.chatEntry .compactableHeight div button:hover {
+    filter: brightness(1.25) !important;
+}
+
+.inviteAnotherFriendButton {
+    margin-right: 15px;
+    margin-top: -4px;
+}
+
 /* nagging about compact mode */
 
 @keyframes fade {


### PR DESCRIPTION
I made a couple of fixes and changes to the chat window:

- Shifted the position of the "Add a friend to make a group chat" button so that it's no longer hovering over the scrollbar
- Added some bottom padding to the chat history to fix a bug where the "(username) is typing..." element was on top of the chat history rather than directly beneath it
- Made the chat action buttons (emoticons, attachment, voice call buttons) glow when hovered over
- Changed the cursor hover state for the chat text entry element to the text cursor
- Hid the scrollbar for the chat text entry element since the height of the element is too small for the scrollbar to be of much use